### PR TITLE
Tidyup 003 revision - 2

### DIFF
--- a/003-dplyr-radix-ordering.Rmd
+++ b/003-dplyr-radix-ordering.Rmd
@@ -103,6 +103,8 @@ To switch to `vec_order()` internally while surprising the least amount of users
 
 American English has been chosen as the default solely because we believe it is the most used locale among R users, so it is the least likely to change existing results. That said, we understand that non-English speakers will not want to set the `.locale` argument *every time* they call `arrange()`, so the global option provides a way to change that default for their scripts. Feedback has indicated that while a global option can decrease reproducibility between sessions, in this case the benefits of it outweigh the costs.
 
+The global option `dplyr.locale` should be used sparingly, as it has the potential to reduce reproducibility across R sessions and affect indirect calls to `arrange()`. It should be viewed as a *convenience option*, which can be helpful for quickly adapting an existing script to the new behavior of `arrange()`, but ideally should not be used in production code.
+
 On certain systems, stringi can be a difficult dependency to install. Because of this, this proposal recommends that stringi only be *suggested* so that users without stringi can still use dplyr.
 
 This proposal relies on `stringi::stri_sort_key()`, which generates the sort key mentioned under Motivation as a proxy that can be ordered in the C locale. However, sort key generation is expensive. In fact, it is often the most expensive part of the entire sorting process. That said, generating a sort key + sorting it in the C locale is generally still 5-10x faster than using `order()` directly. If performance is critical, users can specify `.locale = "C"` to get the maximum benefits of radix ordering.

--- a/003-dplyr-radix-ordering.md
+++ b/003-dplyr-radix-ordering.md
@@ -192,6 +192,13 @@ change that default for their scripts. Feedback has indicated that while
 a global option can decrease reproducibility between sessions, in this
 case the benefits of it outweigh the costs.
 
+The global option `dplyr.locale` should be used sparingly, as it has the
+potential to reduce reproducibility across R sessions and affect
+indirect calls to `arrange()`. It should be viewed as a *convenience
+option*, which can be helpful for quickly adapting an existing script to
+the new behavior of `arrange()`, but ideally should not be used in
+production code.
+
 On certain systems, stringi can be a difficult dependency to install.
 Because of this, this proposal recommends that stringi only be
 *suggested* so that users without stringi can still use dplyr.


### PR DESCRIPTION
This revision:
- Renames the global option `tidyverse.locale_collation` to `dplyr.locale`.
- Elaborates on how we expect `dplyr.locale` to be used.

This reflects our decision to initially take a more conservative approach with the global option override, since it is mainly for convenience and is not a practice that we'd like to encourage throughout all of the tidyverse.