### PR TITLE
Revise 003 to reflect that `dplyr_locale()` will default to the C locale

### DIFF
--- a/003-dplyr-radix-ordering.Rmd
+++ b/003-dplyr-radix-ordering.Rmd
@@ -14,9 +14,9 @@ editor_options:
 
 ## Abstract
 
-As of dplyr 1.0.6, `arrange()` uses a modified version of `base::order()` to sort columns of a data frame.
-Recently, vctrs has gained `vec_order()`, a fast radix ordering function with first class support for data frames and custom vctrs types, along with enhanced character ordering.
-The purpose of this tidyup is to propose switching `arrange()` from `order()` to `vec_order()` in the most user-friendly way possible.
+As of dplyr 1.0.9, `arrange()` uses a modified version of `base::order()` to sort columns of a data frame.
+Recently, vctrs gained `vec_order_radix()`, a fast radix ordering function with first class support for data frames and custom vctrs types, along with enhanced character ordering.
+The purpose of this tidyup is to propose switching `arrange()` from `order()` to `vec_order_radix()` in the most user-friendly way possible.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ Radix ordering character vectors is only possible in the C locale, but the shell
 Because R is justifiably hesitant to break backwards compatibility, if *any* character vector is present, the entire ordering procedure falls back to a much slower shell sort.
 Because dplyr uses `order()` internally, the performance of `arrange()` is negatively affected by this fallback.
 
-Inspired by the performance of the radix ordering algorithm, and by its many practical applications for data science, a radix order-based `vec_order()` was added to vctrs, which has the following benefits:
+Inspired by the performance of the radix ordering algorithm, and by its many practical applications for data science, a radix order-based `vec_order_radix()` was added to vctrs, which has the following benefits:
 
 -   Radix ordering on all atomic types.
 
@@ -39,7 +39,8 @@ It is worth looking at a quick example that demonstrates just how fast this radi
 
 ```{r}
 library(stringi)
-library(vctrs) # r-lib/vctrs#1435
+library(vctrs)
+vec_order_radix <- vctrs:::vec_order_radix
 set.seed(123)
 
 # 10,000 random strings, sampled to a total size of 1,000,000
@@ -55,19 +56,22 @@ x <- sample(dictionary, size = n_total, replace = TRUE)
 
 head(x)
 
-# Force `order()` to use the C locale to match `vec_order()`
+# Force `order()` to use the C locale to match `vec_order_radix()`
 bench::mark(
   base = withr::with_locale(c(LC_COLLATE = "C"), order(x)),
-  vctrs = vec_order(x)
+  vctrs = vec_order_radix(x)
 )
 
-# Force `vec_order()` to use the American English locale, which is also
+# Force `vec_order_radix()` to use the American English locale, which is also
 # my system locale. To do that we'll need to generate a sort key, which
 # we can sort in the C locale, but the result will be like we sorted
 # directly in the American English locale.
 bench::mark(
   base = order(x),
-  vctrs = vec_order(x, chr_transform = ~stri_sort_key(.x, locale = "en_US"))
+  vctrs = vec_order_radix(
+    x = x, 
+    chr_proxy_collate = ~stri_sort_key(.x, locale = "en_US")
+  )
 )
 
 # Generating the sort key takes most of the time
@@ -76,8 +80,8 @@ bench::mark(
 )
 ```
 
-In dplyr, we'd like to utilize `vec_order()` while breaking as little code as possible.
-Switching to `vec_order()` has many potential positive impacts, including:
+In dplyr, we'd like to utilize `vec_order_radix()` while breaking as little code as possible.
+Switching to `vec_order_radix()` has many potential positive impacts, including:
 
 -   Improved performance when ordering character vectors.
 
@@ -89,7 +93,7 @@ Switching to `vec_order()` has many potential positive impacts, including:
     For example, `"en_US"` on a Mac is approximately equivalent to `"English_United States.1252"` on Windows.
 
 -   Improved consistency within the tidyverse.
-    Specifically, with stringr, which defaults to the `"en"` locale and has an explicit argument for changing the locale, i.e. `stringr::str_order(locale = "en")`.
+    Specifically, with stringr, which has an explicit argument for changing the locale, i.e. `stringr::str_order(locale = "en")` that utilizes the locale identifiers from stringi.
 
 However, making this switch also has potential negative impacts:
 
@@ -99,9 +103,9 @@ However, making this switch also has potential negative impacts:
 
 ## Solution
 
-To switch to `vec_order()` internally while surprising the least amount of users, it is proposed that the data frame method for `arrange()` gain a new argument, `.locale`, with the following properties:
+To switch to `vec_order_radix()` internally while surprising the least amount of users, it is proposed that the data frame method for `arrange()` gain a new argument, `.locale`, with the following properties:
 
--   Defaults to `dplyr_locale()`, see below.
+-   Defaults to `dplyr_locale()`, which typically returns the `"C"` locale, but can be overriden, see below.
 -   If stringi is installed, allow a string locale identifier, such as `"fr"` for French, for explicitly adjusting the locale. If stringi is not installed, and the user has explicitly specified a locale identifier, an error will be thrown.
 -   Allow `"C"` to be specified as a special case, which is an explicit way to request the C locale. If the exact details of the ordering are not critical, this is often much faster than specifying a locale identifier. This does not require stringi.
 
@@ -109,64 +113,81 @@ To switch to `vec_order()` internally while surprising the least amount of users
 Its purpose is to return a string containing the default locale to sort with.
 It has the following properties:
 
--   If stringi is installed, the American English locale, `"en"`, is used as the default.
-
--   If stringi is not installed, the C locale, `"C"`, will be used.
-    A warning will be thrown informing the user of this fallback behavior, and encouraging them to silence the warning by either installing stringi or explicitly specifying `.locale = "C"`.
+-   It defaults to returning `"C"`, for the C locale.
 
 -   Alternatively, to globally override the above default behavior, the global option, `dplyr.locale`, can be set to either `"C"` or a string locale identifier.
     Setting this to anything except `"C"` would require stringi.
 
-American English has been chosen as the default solely because we believe it is the most used locale among R users, so it is the least likely to change existing results.
-That said, we understand that non-English speakers will not want to set the `.locale` argument *every time* they call `arrange()`, so the global option provides a way to change that default for their scripts.
-Feedback has indicated that while a global option can decrease reproducibility between sessions, in this case the benefits of it outweigh the costs.
+C has been chosen as the default because it is the most reproducible option.
+The C locale is available in all versions of R and across all operating systems, and works the same everywhere.
+This satisfies one of the main goals of this tidyup, improving the reproducibility of `arrange()` when compared with the current behavior of `LC_COLLATE`.
+The C locale is also fairly close to the American English locale (i.e. `"en"`), with the main difference being how case-sensitivity is treated, but this rarely makes a practical difference in a data analysis.
 
-The global option `dplyr.locale` should be used sparingly, as it has the potential to reduce reproducibility across R sessions and affect indirect calls to `arrange()`.
-It should be viewed as a *convenience option*, which can be helpful for quickly adapting an existing script to the new behavior of `arrange()`, but ideally should not be used in production code.
+The global option `dplyr.locale` has been provided as an "escape hatch" that should be used sparingly, as it has the potential to reduce reproducibility across R sessions.
+It has two main uses:
+
+-   Quickly adapting an existing script to the new behavior of `arrange()` by overriding the locale at the top of the script to switch back to the previous behavior.
+    In the long term, we suggest explicitly supplying `.locale` in all affected calls to `arrange()` instead.
+
+-   Locally overriding the locale when `arrange()` is called from within a function that you don't control.
+    In this case, we recommend using `rlang::with_options()` to limit the scope in which the locale is overriden.
+
+Feedback has indicated that while a global option can decrease reproducibility between sessions, in this case the benefits of it outweigh the costs.
 
 On certain systems, stringi can be a difficult dependency to install.
 Because of this, this proposal recommends that stringi only be *suggested* so that users without stringi can still use dplyr.
 
-This proposal relies on `stringi::stri_sort_key()`, which generates the sort key mentioned under Motivation as a proxy that can be ordered in the C locale.
+This proposal relies on `stringi::stri_sort_key()` when a stringi locale identifier is supplied, which generates the sort key mentioned under Motivation as a proxy that can be ordered in the C locale.
 However, sort key generation is expensive.
-In fact, it is often the most expensive part of the entire sorting process.
+In fact, it is often the most expensive part of the entire sorting process, which is one of the reasons that the C locale is the default.
 That said, generating a sort key + sorting it in the C locale is generally still 5-10x faster than using `order()` directly.
-If performance is critical, users can specify `.locale = "C"` to get the maximum benefits of radix ordering.
 
 ## Implementation
 
--   Using `vec_order()` in `arrange()`, and adding `.locale`
+-   Using `vec_order_radix()` in `arrange()`, and adding `.locale`
 
-    -   <https://github.com/tidyverse/dplyr/pull/5942>
-
--   Renaming `vec_order_radix()` to `vec_order()`
-
-    -   <https://github.com/r-lib/vctrs/pull/1435>
+    -   <https://github.com/tidyverse/dplyr/pull/6263>
 
 ## Backwards Compatibility
 
 ### arrange()
 
-The proposal outlined above is purposefully as conservative as possible, preserving the results of programs using the American English locale, which is the most widely used locale in R, while sacrificing a bit of performance from the generation of the sort key.
-
-That said, this proposal will impact non-English Latin script languages.
-For example, in a majority of Latin script languages, including `"en"`, ø sorts after o, but before p.
-However, a few languages, such as Danish, sort ø as a unique character after z.
-Danish users that have `LC_COLLATE` set to Danish may be surprised that `arrange()` would now be placing ø in the "wrong order" even though they have set that global option.
-The fix would be to either set `.locale = "da"` in their calls to `arrange()`, or to set `options(dplyr.locale = "da")` to override this default globally.
+The proposal outlined above should preserve the results of most programs using the American English locale.
+The main difference between the C locale and American English is related to case-sensitivity.
+In the C locale, the English alphabet is grouped by *case*, while in English locales the alphabet is grouped by *letter*:
 
 ```{r, message=FALSE}
-library(dplyr) # tidyverse/dplyr#5942
-library(withr)
+library(dplyr) # tidyverse/dplyr#6263
 
-tbl <- tibble(x = c("ø", "o", "p", "z"))
+df <- tibble(x = c("a", "b", "C", "B", "c"))
+df
 
-# `"en"` default
+# The C locale groups the English alphabet by case, placing uppercase letters
+# before lowercase letters
+arrange(df, x)
+
+# The American English locale groups the alphabet by letter
+arrange(df, x, .locale = "en")
+```
+
+This rarely has a practical difference in a data analysis.
+The C locale will return identical results to the American English locale as long as the case is consistent between observations, like with the following two IDs: `"AD25" < "AG66"`, or with proper nouns, which are often either capitalized consistently or not capitalized at all: `"America" < "Japan"` or `"america" < "japan"`.
+
+With non-English Latin script languages, we expect there to be more meaningful differences.
+For example, in Spanish the `n` with a tilde above it is sorted directly after `n`, but in the C locale this is placed after `z`.
+
+```{r}
+tbl <- tibble(x = c("\u00F1", "n", "z"))
+tbl
+
 arrange(tbl, x)
 
-# Set the locale in `arrange()` directly
-arrange(tbl, x, .locale = "da")
+arrange(tbl, x, .locale = "es")
 ```
+
+Spanish users that have `LC_COLLATE` set to Spanish may be surprised that `arrange()` would now be placing this character in the "wrong order" even though they have set that global option.
+The fix would be to either set `.locale = "es"` in their calls to `arrange()`, or to set `options(dplyr.locale = "es")` to override this default globally.
+We expect this issue to affect a small number of users, due to the sheer magnitude of users that use English as their system locale.
 
 ### arrange_at/if/all()
 
@@ -204,20 +225,21 @@ With a large script containing multiple calls to `arrange()`, each call would ha
 Additionally, if a function from a package that a user didn't control called `arrange()` internally, then without a global option they would have no way to adjust the locale until that package author exposed the new `.locale` argument.
 Ultimately, in this case the benefits of the global option outweigh the potential reproducibility issues that might arise from it.
 
-### Defaulting to the C locale
+### Defaulting to the American English locale if stringi was installed
 
-Another alternative is to default `arrange()` to the C locale, while still allowing users to specify `.locale` for ordering in alternative locales.
+A previous version of this proposal changed the behavior of `dplyr_locale()` so that it:
 
--   This has the benefit of making it clearer that stringi is an optional dependency, which would only be used if a user requests a specific locale identifier.
-    The default behavior would never require stringi.
+-   Defaulted to `"en"` if stringi was installed
 
--   Additionally, the performance improvements would be even more substantial since no sort key would be generated by default.
+-   Fell back to `"C"` with a warning if stringi wasn't installed
 
--   However, this would have the potential to alter nearly every call to `arrange()`, since the C locale is not identical to the American English locale.
-    In particular, in the C locale all capital letters are ordered before lowercase ones, such as: `c(A, B, a, b)` , while in the American English locale letters are first grouped together regardless of capitalization, and then lowercase letters are placed before uppercase ones, like: `c(a, A, b, B)`.
-    This may look like a small difference, but it would surprise enough users to justify not defaulting to the C locale.
+-   Still allowed `dplyr.locale` to override this behavior
 
--   This is also not as consistent with stringr, which defaults to `"en"`.
+This seemed reasonable since most R users use an English locale, and that would mean their scripts had very little chance of breaking from this change.
+However, on 2022-05-11 we realized that in practice this would cause more confusion than it is worth.
+In particular, if you are a package developer relying on dplyr, then the default behavior of `arrange()` would change for you depending on whether or not stringi was installed.
+This would result in difficult to debug situations where you might locally write tests with stringi installed, but then on CI your tests might fail or throw warnings if you forget to `Import` stringi (even if you weren't working with character columns!).
+By defaulting to the C locale, the default behavior of `arrange()` will work the same everywhere, and if package developers explicitly set `.locale` to anything else, such as `"en"`, then this will be a clear signal that they have opted into an optional behavior and need to add stringi as a dependency of their package.
 
 ### Tagged character vectors
 

--- a/003-dplyr-radix-ordering.md
+++ b/003-dplyr-radix-ordering.md
@@ -9,30 +9,31 @@
 
 ## Abstract
 
-As of dplyr 1.0.6, `arrange()` uses a modified version of
-`base::order()` to sort columns of a data frame. Recently, vctrs has
-gained `vec_order()`, a fast radix ordering function with first class
+As of dplyr 1.0.9, `arrange()` uses a modified version of
+`base::order()` to sort columns of a data frame. Recently, vctrs gained
+`vec_order_radix()`, a fast radix ordering function with first class
 support for data frames and custom vctrs types, along with enhanced
 character ordering. The purpose of this tidyup is to propose switching
-`arrange()` from `order()` to `vec_order()` in the most user-friendly
-way possible.
+`arrange()` from `order()` to `vec_order_radix()` in the most
+user-friendly way possible.
 
 ## Motivation
 
-Thanks to the data.table team, R &gt;= 3.3 gained support for an
-extremely fast radix ordering algorithm in `order()`. This has become
-the default algorithm for ordering most atomic types, with the notable
-exception of character vectors. Radix ordering character vectors is only
-possible in the C locale, but the shell sort currently in use by
-`order()` respects the system locale. Because R is justifiably hesitant
-to break backwards compatibility, if *any* character vector is present,
-the entire ordering procedure falls back to a much slower shell sort.
-Because dplyr uses `order()` internally, the performance of `arrange()`
-is negatively affected by this fallback.
+Thanks to the data.table team, R \>= 3.3 gained support for an extremely
+fast radix ordering algorithm in `order()`. This has become the default
+algorithm for ordering most atomic types, with the notable exception of
+character vectors. Radix ordering character vectors is only possible in
+the C locale, but the shell sort currently in use by `order()` respects
+the system locale. Because R is justifiably hesitant to break backwards
+compatibility, if *any* character vector is present, the entire ordering
+procedure falls back to a much slower shell sort. Because dplyr uses
+`order()` internally, the performance of `arrange()` is negatively
+affected by this fallback.
 
 Inspired by the performance of the radix ordering algorithm, and by its
 many practical applications for data science, a radix order-based
-`vec_order()` was added to vctrs, which has the following benefits:
+`vec_order_radix()` was added to vctrs, which has the following
+benefits:
 
 -   Radix ordering on all atomic types.
 
@@ -51,7 +52,8 @@ this radix ordering algorithm is when compared against the defaults of
 
 ``` r
 library(stringi)
-library(vctrs) # r-lib/vctrs#1435
+library(vctrs)
+vec_order_radix <- vctrs:::vec_order_radix
 set.seed(123)
 
 # 10,000 random strings, sampled to a total size of 1,000,000
@@ -73,37 +75,40 @@ head(x)
     ## [5] "wcIz5PS93kRUC"                  "2yy09KfokjQoBwumnUascCD"
 
 ``` r
-# Force `order()` to use the C locale to match `vec_order()`
+# Force `order()` to use the C locale to match `vec_order_radix()`
 bench::mark(
   base = withr::with_locale(c(LC_COLLATE = "C"), order(x)),
-  vctrs = vec_order(x)
+  vctrs = vec_order_radix(x)
 )
 ```
 
-    ## # A tibble: 2 x 6
+    ## # A tibble: 2 × 6
     ##   expression      min   median `itr/sec` mem_alloc `gc/sec`
     ##   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-    ## 1 base          1.61s    1.61s     0.621    3.89MB      0  
-    ## 2 vctrs       18.22ms  20.77ms    46.9     12.71MB     21.9
+    ## 1 base          1.61s    1.61s     0.622    8.34MB      0  
+    ## 2 vctrs       32.89ms  36.96ms    27.4      12.7MB     32.0
 
 ``` r
-# Force `vec_order()` to use the American English locale, which is also
+# Force `vec_order_radix()` to use the American English locale, which is also
 # my system locale. To do that we'll need to generate a sort key, which
 # we can sort in the C locale, but the result will be like we sorted
 # directly in the American English locale.
 bench::mark(
   base = order(x),
-  vctrs = vec_order(x, chr_transform = ~stri_sort_key(.x, locale = "en_US"))
+  vctrs = vec_order_radix(
+    x = x, 
+    chr_proxy_collate = ~stri_sort_key(.x, locale = "en_US")
+  )
 )
 ```
 
     ## Warning: Some expressions had a GC in every iteration; so filtering is disabled.
 
-    ## # A tibble: 2 x 6
+    ## # A tibble: 2 × 6
     ##   expression      min   median `itr/sec` mem_alloc `gc/sec`
     ##   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-    ## 1 base          6.48s    6.48s     0.154    3.81MB     0   
-    ## 2 vctrs      642.76ms 642.76ms     1.56    20.21MB     3.11
+    ## 1 base          6.25s    6.25s     0.160    3.81MB     0   
+    ## 2 vctrs      661.42ms 661.42ms     1.51    20.21MB     1.51
 
 ``` r
 # Generating the sort key takes most of the time
@@ -112,16 +117,14 @@ bench::mark(
 )
 ```
 
-    ## Warning: Some expressions had a GC in every iteration; so filtering is disabled.
-
-    ## # A tibble: 1 x 6
+    ## # A tibble: 1 × 6
     ##   expression      min   median `itr/sec` mem_alloc `gc/sec`
     ##   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-    ## 1 sort_key      656ms    656ms      1.53    7.63MB     1.53
+    ## 1 sort_key      609ms    609ms      1.64    7.63MB        0
 
-In dplyr, we’d like to utilize `vec_order()` while breaking as little
-code as possible. Switching to `vec_order()` has many potential positive
-impacts, including:
+In dplyr, we’d like to utilize `vec_order_radix()` while breaking as
+little code as possible. Switching to `vec_order_radix()` has many
+potential positive impacts, including:
 
 -   Improved performance when ordering character vectors.
 
@@ -140,9 +143,9 @@ impacts, including:
     Windows.
 
 -   Improved consistency within the tidyverse. Specifically, with
-    stringr, which defaults to the `"en"` locale and has an explicit
-    argument for changing the locale,
-    i.e. `stringr::str_order(locale = "en")`.
+    stringr, which has an explicit argument for changing the locale,
+    i.e. `stringr::str_order(locale = "en")` that utilizes the locale
+    identifiers from stringi.
 
 However, making this switch also has potential negative impacts:
 
@@ -154,11 +157,13 @@ However, making this switch also has potential negative impacts:
 
 ## Solution
 
-To switch to `vec_order()` internally while surprising the least amount
-of users, it is proposed that the data frame method for `arrange()` gain
-a new argument, `.locale`, with the following properties:
+To switch to `vec_order_radix()` internally while surprising the least
+amount of users, it is proposed that the data frame method for
+`arrange()` gain a new argument, `.locale`, with the following
+properties:
 
--   Defaults to `dplyr_locale()`, see below.
+-   Defaults to `dplyr_locale()`, which typically returns the `"C"`
+    locale, but can be overriden, see below.
 -   If stringi is installed, allow a string locale identifier, such as
     `"fr"` for French, for explicitly adjusting the locale. If stringi
     is not installed, and the user has explicitly specified a locale
@@ -172,109 +177,171 @@ a new argument, `.locale`, with the following properties:
 to return a string containing the default locale to sort with. It has
 the following properties:
 
--   If stringi is installed, the American English locale, `"en"`, is
-    used as the default.
-
--   If stringi is not installed, the C locale, `"C"`, will be used. A
-    warning will be thrown informing the user of this fallback behavior,
-    and encouraging them to silence the warning by either installing
-    stringi or explicitly specifying `.locale = "C"`.
+-   It defaults to returning `"C"`, for the C locale.
 
 -   Alternatively, to globally override the above default behavior, the
     global option, `dplyr.locale`, can be set to either `"C"` or a
     string locale identifier. Setting this to anything except `"C"`
     would require stringi.
 
-American English has been chosen as the default solely because we
-believe it is the most used locale among R users, so it is the least
-likely to change existing results. That said, we understand that
-non-English speakers will not want to set the `.locale` argument *every
-time* they call `arrange()`, so the global option provides a way to
-change that default for their scripts. Feedback has indicated that while
-a global option can decrease reproducibility between sessions, in this
-case the benefits of it outweigh the costs.
+C has been chosen as the default because it is the most reproducible
+option. The C locale is available in all versions of R and across all
+operating systems, and works the same everywhere. This satisfies one of
+the main goals of this tidyup, improving the reproducibility of
+`arrange()` when compared with the current behavior of `LC_COLLATE`. The
+C locale is also fairly close to the American English locale
+(i.e. `"en"`), with the main difference being how case-sensitivity is
+treated, but this rarely makes a practical difference in a data
+analysis.
 
-The global option `dplyr.locale` should be used sparingly, as it has the
-potential to reduce reproducibility across R sessions and affect
-indirect calls to `arrange()`. It should be viewed as a *convenience
-option*, which can be helpful for quickly adapting an existing script to
-the new behavior of `arrange()`, but ideally should not be used in
-production code.
+The global option `dplyr.locale` has been provided as an “escape hatch”
+that should be used sparingly, as it has the potential to reduce
+reproducibility across R sessions. It has two main uses:
+
+-   Quickly adapting an existing script to the new behavior of
+    `arrange()` by overriding the locale at the top of the script to
+    switch back to the previous behavior. In the long term, we suggest
+    explicitly supplying `.locale` in all affected calls to `arrange()`
+    instead.
+
+-   Locally overriding the locale when `arrange()` is called from within
+    a function that you don’t control. In this case, we recommend using
+    `rlang::with_options()` to limit the scope in which the locale is
+    overriden.
+
+Feedback has indicated that while a global option can decrease
+reproducibility between sessions, in this case the benefits of it
+outweigh the costs.
 
 On certain systems, stringi can be a difficult dependency to install.
 Because of this, this proposal recommends that stringi only be
 *suggested* so that users without stringi can still use dplyr.
 
-This proposal relies on `stringi::stri_sort_key()`, which generates the
-sort key mentioned under Motivation as a proxy that can be ordered in
-the C locale. However, sort key generation is expensive. In fact, it is
-often the most expensive part of the entire sorting process. That said,
-generating a sort key + sorting it in the C locale is generally still
-5-10x faster than using `order()` directly. If performance is critical,
-users can specify `.locale = "C"` to get the maximum benefits of radix
-ordering.
+This proposal relies on `stringi::stri_sort_key()` when a stringi locale
+identifier is supplied, which generates the sort key mentioned under
+Motivation as a proxy that can be ordered in the C locale. However, sort
+key generation is expensive. In fact, it is often the most expensive
+part of the entire sorting process, which is one of the reasons that the
+C locale is the default. That said, generating a sort key + sorting it
+in the C locale is generally still 5-10x faster than using `order()`
+directly.
 
 ## Implementation
 
--   Using `vec_order()` in `arrange()`, and adding `.locale`
+-   Using `vec_order_radix()` in `arrange()`, and adding `.locale`
 
-    -   <https://github.com/tidyverse/dplyr/pull/5942>
-
--   Renaming `vec_order_radix()` to `vec_order()`
-
-    -   <https://github.com/r-lib/vctrs/pull/1435>
+    -   <https://github.com/tidyverse/dplyr/pull/6263>
 
 ## Backwards Compatibility
 
 ### arrange()
 
-The proposal outlined above is purposefully as conservative as possible,
-preserving the results of programs using the American English locale,
-which is the most widely used locale in R, while sacrificing a bit of
-performance from the generation of the sort key.
-
-That said, this proposal will impact non-English Latin script languages.
-For example, in a majority of Latin script languages, including `"en"`,
-ø sorts after o, but before p. However, a few languages, such as Danish,
-sort ø as a unique character after z. Danish users that have
-`LC_COLLATE` set to Danish may be surprised that `arrange()` would now
-be placing ø in the “wrong order” even though they have set that global
-option. The fix would be to either set `.locale = "da"` in their calls
-to `arrange()`, or to set `options(dplyr.locale = "da")` to override
-this default globally.
+The proposal outlined above should preserve the results of most programs
+using the American English locale. The main difference between the C
+locale and American English is related to case-sensitivity. In the C
+locale, the English alphabet is grouped by *case*, while in English
+locales the alphabet is grouped by *letter*:
 
 ``` r
-library(dplyr) # tidyverse/dplyr#5942
-library(withr)
+library(dplyr) # tidyverse/dplyr#6263
 
-tbl <- tibble(x = c("ø", "o", "p", "z"))
+df <- tibble(x = c("a", "b", "C", "B", "c"))
+df
+```
 
-# `"en"` default
+    ## # A tibble: 5 × 1
+    ##   x    
+    ##   <chr>
+    ## 1 a    
+    ## 2 b    
+    ## 3 C    
+    ## 4 B    
+    ## 5 c
+
+``` r
+# The C locale groups the English alphabet by case, placing uppercase letters
+# before lowercase letters
+arrange(df, x)
+```
+
+    ## # A tibble: 5 × 1
+    ##   x    
+    ##   <chr>
+    ## 1 B    
+    ## 2 C    
+    ## 3 a    
+    ## 4 b    
+    ## 5 c
+
+``` r
+# The American English locale groups the alphabet by letter
+arrange(df, x, .locale = "en")
+```
+
+    ## # A tibble: 5 × 1
+    ##   x    
+    ##   <chr>
+    ## 1 a    
+    ## 2 b    
+    ## 3 B    
+    ## 4 c    
+    ## 5 C
+
+This rarely has a practical difference in a data analysis. The C locale
+will return identical results to the American English locale as long as
+the case is consistent between observations, like with the following two
+IDs: `"AD25" < "AG66"`, or with proper nouns, which are often either
+capitalized consistently or not capitalized at all:
+`"America" < "Japan"` or `"america" < "japan"`.
+
+With non-English Latin script languages, we expect there to be more
+meaningful differences. For example, in Spanish the `n` with a tilde
+above it is sorted directly after `n`, but in the C locale this is
+placed after `z`.
+
+``` r
+tbl <- tibble(x = c("\u00F1", "n", "z"))
+tbl
+```
+
+    ## # A tibble: 3 × 1
+    ##   x    
+    ##   <chr>
+    ## 1 ñ    
+    ## 2 n    
+    ## 3 z
+
+``` r
 arrange(tbl, x)
 ```
 
-    ## # A tibble: 4 x 1
+    ## # A tibble: 3 × 1
     ##   x    
     ##   <chr>
-    ## 1 o    
-    ## 2 ø    
-    ## 3 p    
-    ## 4 z
+    ## 1 n    
+    ## 2 z    
+    ## 3 ñ
 
 ``` r
-# Set the locale in `arrange()` directly
-arrange(tbl, x, .locale = "da")
+arrange(tbl, x, .locale = "es")
 ```
 
-    ## # A tibble: 4 x 1
+    ## # A tibble: 3 × 1
     ##   x    
     ##   <chr>
-    ## 1 o    
-    ## 2 p    
-    ## 3 z    
-    ## 4 ø
+    ## 1 n    
+    ## 2 ñ    
+    ## 3 z
 
-### arrange\_at/if/all()
+Spanish users that have `LC_COLLATE` set to Spanish may be surprised
+that `arrange()` would now be placing this character in the “wrong
+order” even though they have set that global option. The fix would be to
+either set `.locale = "es"` in their calls to `arrange()`, or to set
+`options(dplyr.locale = "es")` to override this default globally. We
+expect this issue to affect a small number of users, due to the sheer
+magnitude of users that use English as their system locale.
+
+### arrange_at/if/all()
 
 While these three variants of `arrange()` are superseded, we have
 decided to add a `.locale` argument to each of them anyways.
@@ -332,32 +399,32 @@ way to adjust the locale until that package author exposed the new
 option outweigh the potential reproducibility issues that might arise
 from it.
 
-### Defaulting to the C locale
+### Defaulting to the American English locale if stringi was installed
 
-Another alternative is to default `arrange()` to the C locale, while
-still allowing users to specify `.locale` for ordering in alternative
-locales.
+A previous version of this proposal changed the behavior of
+`dplyr_locale()` so that it:
 
--   This has the benefit of making it clearer that stringi is an
-    optional dependency, which would only be used if a user requests a
-    specific locale identifier. The default behavior would never require
-    stringi.
+-   Defaulted to `"en"` if stringi was installed
 
--   Additionally, the performance improvements would be even more
-    substantial since no sort key would be generated by default.
+-   Fell back to `"C"` with a warning if stringi wasn’t installed
 
--   However, this would have the potential to alter nearly every call to
-    `arrange()`, since the C locale is not identical to the American
-    English locale. In particular, in the C locale all capital letters
-    are ordered before lowercase ones, such as: `c(A, B, a, b)` , while
-    in the American English locale letters are first grouped together
-    regardless of capitalization, and then lowercase letters are placed
-    before uppercase ones, like: `c(a, A, b, B)`. This may look like a
-    small difference, but it would surprise enough users to justify not
-    defaulting to the C locale.
+-   Still allowed `dplyr.locale` to override this behavior
 
--   This is also not as consistent with stringr, which defaults to
-    `"en"`.
+This seemed reasonable since most R users use an English locale, and
+that would mean their scripts had very little chance of breaking from
+this change. However, on 2022-05-11 we realized that in practice this
+would cause more confusion than it is worth. In particular, if you are a
+package developer relying on dplyr, then the default behavior of
+`arrange()` would change for you depending on whether or not stringi was
+installed. This would result in difficult to debug situations where you
+might locally write tests with stringi installed, but then on CI your
+tests might fail or throw warnings if you forget to `Import` stringi
+(even if you weren’t working with character columns!). By defaulting to
+the C locale, the default behavior of `arrange()` will work the same
+everywhere, and if package developers explicitly set `.locale` to
+anything else, such as `"en"`, then this will be a clear signal that
+they have opted into an optional behavior and need to add stringi as a
+dependency of their package.
 
 ### Tagged character vectors
 


### PR DESCRIPTION
This revises the 003 tidyup to reflect that we now think `arrange()` should default to the C locale, rather than `"en"` if stringi is installed with a noisy fallback to C if not.

This mainly comes from a realization that the current behavior would be very frustrating for package developers that rely on dplyr. If they call `arrange()` at all in their package, then that essentially makes stringi an Imports dependency in their package, even if they aren't sorting character vectors, since it would warn unconditionally about falling back to the C locale if stringi wasn't there. This could be extremely annoying when developing, since you might have stringi locally on your computer but it may not be installed on CI.

Defaulting to C works everywhere all the time, and if a developer explicitly sets `.locale = "en"` then that is a clear signal that they are opting into optional behavior that requires stringi, so they should Import it.

The main sections with changes are:
- Solution
- Backwards compatibility - `arrange()`
- Alternatives - Defaulting to the American English locale if stringi was installed

If you want to reread the updated tidyup without the diffs, you can go here https://github.com/tidyverse/tidyups/blob/22ad630c7576ae0b5b7627416240c66ff385e395/003-dplyr-radix-ordering.md

Corresponding dplyr PR https://github.com/tidyverse/dplyr/pull/6263