### PR TITLE
Mention the code review principles in the Contributors section

### DIFF
--- a/004-governance.Rmd
+++ b/004-governance.Rmd
@@ -80,13 +80,13 @@ Authors are expected to follow our standard processes, such as:
 -   **Welcoming and inclusive**: Kindness and gratitude are core values of the tidyverse and we strive to create an [inclusive atmosphere](https://github.com/tidyverse/tidyverse.org/blob/master/CODE_OF_CONDUCT.md) in our GitHub interactions.
     As an author, you'll be listed as a "member" of the tidyverse across all repos, so also please bear in mind your special status in other repos.
 
--   **Code contribution**: code is usually contributed via PR, even for authors who could push directly.
+-   **Code contribution**: code is usually contributed via [PR](https://code-review.tidyverse.org/author/submitting.html), even for authors who could push directly.
 
 -   **Communication**: authors are involved in most of the interactions with contributors and thus need to set a welcoming and inclusive tone for the project.
 
 -   **PR review**: all pull requests should be reviewed by at least one other author.
     In general, there is no expectation that PRs contain clean commit histories, but it's appreciated where possible.
-    Once a reviewer has marked a PR as approved, the original author finishes any remaining tasks and then merges it.
+    Once a reviewer has [marked a PR as approved](https://code-review.tidyverse.org/reviewer/comments.html#sec-approve-with-comments), the original author finishes any remaining tasks and then merges it.
 
 -   **Backward compatibility**: any backward incompatible changes (i.e. changes that cause reverse dependencies to fail `R CMD check` or are likely to cause problems in user code) must be approved by the maintainer.
     Significant backward incompatible changes need to be accompanied with a plan for how they will be communicated to the community.

--- a/004-governance.Rmd
+++ b/004-governance.Rmd
@@ -56,6 +56,7 @@ Contributors:
 
 Anyone can become a contributor: there is no expectation of commitment to the project, no required set of skills, and no selection process.
 The only requirements are to follow the [code of conduct](https://github.com/tidyverse/ggplot2/blob/master/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/tidyverse/ggplot2/blob/master/CONTRIBUTING.md).
+Our [code review principles](https://code-review.tidyverse.org/) provide advice on best practices for contributing to our packages.
 
 Packages don't maintain an explicit list of contributors but acknowledge them in blog posts, using data from GitHub aggregated by `usethis::use_tidy_thanks()`.
 Contributors who implement user facing changes are also acknowledged in `NEWS.md`.

--- a/004-governance.md
+++ b/004-governance.md
@@ -82,6 +82,8 @@ only requirements are to follow the [code of
 conduct](https://github.com/tidyverse/ggplot2/blob/master/CODE_OF_CONDUCT.md)
 and [contributing
 guidelines](https://github.com/tidyverse/ggplot2/blob/master/CONTRIBUTING.md).
+Our [code review principles](https://code-review.tidyverse.org/) provide
+advice on best practices for contributing to our packages.
 
 Packages don’t maintain an explicit list of contributors but acknowledge
 them in blog posts, using data from GitHub aggregated by

--- a/004-governance.md
+++ b/004-governance.md
@@ -118,8 +118,9 @@ Authors are expected to follow our standard processes, such as:
   “member” of the tidyverse across all repos, so also please bear in
   mind your special status in other repos.
 
-- **Code contribution**: code is usually contributed via PR, even for
-  authors who could push directly.
+- **Code contribution**: code is usually contributed via
+  [PR](https://code-review.tidyverse.org/author/submitting.html), even
+  for authors who could push directly.
 
 - **Communication**: authors are involved in most of the interactions
   with contributors and thus need to set a welcoming and inclusive tone
@@ -128,8 +129,9 @@ Authors are expected to follow our standard processes, such as:
 - **PR review**: all pull requests should be reviewed by at least one
   other author. In general, there is no expectation that PRs contain
   clean commit histories, but it’s appreciated where possible. Once a
-  reviewer has marked a PR as approved, the original author finishes any
-  remaining tasks and then merges it.
+  reviewer has [marked a PR as
+  approved](https://code-review.tidyverse.org/reviewer/comments.html#sec-approve-with-comments),
+  the original author finishes any remaining tasks and then merges it.
 
 - **Backward compatibility**: any backward incompatible changes
   (i.e. changes that cause reverse dependencies to fail `R CMD check` or


### PR DESCRIPTION
This seemed like the most natural place to put it, since it talks about issues and pull requests and is targeting contributors who could gain a lot from the guide

See also
https://github.com/r-lib/usethis/pull/1833
https://github.com/tidyverse/tidyverse.org/pull/638